### PR TITLE
카카오 공유하기 기능

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,12 @@
       content="https://marvelous-taffy-578889.netlify.app/OpenGraphImg.jpg"
     />
     <meta name="twitter:url" content="https://open-n-mind.netlify.app" />
+    <!-- 카카오톡 공유하기 -->
+    <script
+      src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.5/kakao.min.js"
+      integrity="sha384-dok87au0gKqJdxs7msEdBPNnKSRT+/mhTVzq+qOhcL464zXwvcrpjeWvyj1kCdq6"
+      crossorigin="anonymous"
+    ></script>
     <title>OpenMind</title>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import ToastContainer from '@components/Toast';
-import FeedPage from '@pages/FeedPage';
+import FeedPage from '@pages/FeedPage/FeedPage';
 import UserList from '@pages/list/UserList';
 import { Routes, Route } from 'react-router-dom';
 

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -44,10 +44,8 @@ function FeedPage() {
   return (
     <>
       <PostHeader
-        name={'홍길동'}
-        imageSource={
-          'https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8'
-        }
+        name={subject.name}
+        imageSource={subject.imageSource}
         subjectId={subjectId}
       />
       <AnswerCluster

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -4,7 +4,12 @@ import PostHeader from './components/PostHeader';
 function FeedPage() {
   return (
     <>
-      <PostHeader />
+      <PostHeader
+        name={'홍길동'}
+        imageSource={
+          'https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8'
+        }
+      />
       <FloatingButton />
     </>
   );

--- a/src/pages/FeedPage/components/KakaoShareButton.jsx
+++ b/src/pages/FeedPage/components/KakaoShareButton.jsx
@@ -12,7 +12,7 @@ function KakaoShareButton({ name, subjectId }) {
       templateId: 121287, // 카카오톡 개발센터에서 설정한 template 설정
       templateArgs: {
         userName: name,
-        questionId: subjectId,
+        id: subjectId,
       },
     });
   };
@@ -20,7 +20,6 @@ function KakaoShareButton({ name, subjectId }) {
   useEffect(() => {
     Kakao.cleanup();
     Kakao.init(KAKAO_APP_KEY);
-    console.log(Kakao.isInitialized());
   }, []);
 
   return (

--- a/src/pages/FeedPage/components/KakaoShareButton.jsx
+++ b/src/pages/FeedPage/components/KakaoShareButton.jsx
@@ -1,13 +1,34 @@
-import IconKakaoShare from '@assets/icons/IconKakaoShare.svg';
+import { useEffect } from 'react';
 
-function KakaoShareButton() {
+import IconKakaoShare from '@assets/icons/IconKakaoShare.svg?react';
+
+const { Kakao } = window;
+
+function KakaoShareButton({ name, subjectId }) {
+  const KAKAO_APP_KEY = import.meta.env.VITE_KAKAO_APP_KEY;
+
+  const handleKakaoShare = () => {
+    Kakao.Share.sendCustom({
+      templateId: 121287, // 카카오톡 개발센터에서 설정한 template 설정
+      templateArgs: {
+        userName: name,
+        questionId: subjectId,
+      },
+    });
+  };
+
+  useEffect(() => {
+    Kakao.cleanup();
+    Kakao.init(KAKAO_APP_KEY);
+    console.log(Kakao.isInitialized());
+  }, []);
+
   return (
-    <button>
-      <img
-        src={IconKakaoShare}
-        alt='카카오톡 공유 아이콘'
+    <button onClick={handleKakaoShare}>
+      <IconKakaoShare
         width='40'
         height='40'
+        aria-label='카카오톡 공유 아이콘'
       />
     </button>
   );

--- a/src/pages/FeedPage/components/LinkCopyButton.jsx
+++ b/src/pages/FeedPage/components/LinkCopyButton.jsx
@@ -1,4 +1,4 @@
-import IconCopyLink from '@assets/icons/IconCopyLink.svg';
+import IconCopyLink from '@assets/icons/IconCopyLink.svg?react';
 import { useToastContext } from '@context/ToastContext';
 
 const copyLink = () => {
@@ -63,7 +63,7 @@ function LinkCopyButton() {
   return (
     <>
       <button onClick={handleClickLinkCopy}>
-        <img src={IconCopyLink} alt='링크 복사 아이콘' width='40' height='40' />
+        <IconCopyLink width='40' height='40' aria-label='링크 복사 아이콘' />
       </button>
     </>
   );

--- a/src/pages/FeedPage/components/PostHeader.jsx
+++ b/src/pages/FeedPage/components/PostHeader.jsx
@@ -6,7 +6,7 @@ import FacebookShareButton from './FacebookShareButton';
 import KakaoShareButton from './KakaoShareButton';
 import LinkCopyButton from './LinkCopyButton';
 
-function PostHeader({ name, imageSource }) {
+function PostHeader({ name, imageSource, subjectId }) {
   return (
     <PostHeaderWrapper>
       <PostTitle>
@@ -14,16 +14,16 @@ function PostHeader({ name, imageSource }) {
       </PostTitle>
       <UserInfo>
         <UserThumbnail>
-          <img src={imageSource} alt={`유저이름의 프로필 이미지`} />
+          <img src={imageSource} alt={`${name}의 프로필 이미지`} />
         </UserThumbnail>
-        <UserName>아초는고양이가뭔데</UserName>
+        <UserName>{name}</UserName>
       </UserInfo>
       <PostUtils>
         <li>
           <LinkCopyButton />
         </li>
         <li>
-          <KakaoShareButton name={name} subjectId={123} />
+          <KakaoShareButton name={name} subjectId={subjectId} />
         </li>
         <li>
           <FacebookShareButton />

--- a/src/pages/FeedPage/components/PostHeader.jsx
+++ b/src/pages/FeedPage/components/PostHeader.jsx
@@ -6,7 +6,7 @@ import FacebookShareButton from './FacebookShareButton';
 import KakaoShareButton from './KakaoShareButton';
 import LinkCopyButton from './LinkCopyButton';
 
-function PostHeader() {
+function PostHeader({ name, imageSource }) {
   return (
     <PostHeaderWrapper>
       <PostTitle>
@@ -14,10 +14,7 @@ function PostHeader() {
       </PostTitle>
       <UserInfo>
         <UserThumbnail>
-          <img
-            src='https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8'
-            alt={`유저이름의 프로필 이미지`}
-          />
+          <img src={imageSource} alt={`유저이름의 프로필 이미지`} />
         </UserThumbnail>
         <UserName>아초는고양이가뭔데</UserName>
       </UserInfo>
@@ -26,7 +23,7 @@ function PostHeader() {
           <LinkCopyButton />
         </li>
         <li>
-          <KakaoShareButton />
+          <KakaoShareButton name={name} subjectId={123} />
         </li>
         <li>
           <FacebookShareButton />


### PR DESCRIPTION
## ✅작업 내역
- 카카오톡 공유하기 버튼을 클릭하면, 유저의 개인 피드 페이지를 카카오톡에 공유 할 수 있습니다.
- FeedPage에서 받아온 데이터를 props로 전달하였습니다.
- 질문 하러 가기 버튼을 클릭하면, 해당 유저의 개인 피드 페이지로 이동합니다.

![image](https://github.com/user-attachments/assets/f9700c1d-24de-43f5-b29c-3b545ff3a949)

## ⚙️카카오톡 공유하기 설정
- 카카오톡 개발자 센터에 등록한 키를 env 파일로 분리하였습니다. 노션에 있는 키값 참고해주세요.
- 템플릿을 추후에 배포할 도메인으로 설정하였기 때문에, **localhost 에서는 제대로 동작하지 않습니다.** (테스트 필요시 말씀해주세요!)
  - 설정 도메인 주소 : https://open-n-mind.netlify.app
