### PR TITLE
feat(Meatball): 답변이 달린 질문만 삭제하기 기능 추가

### DIFF
--- a/src/components/Meatball.jsx
+++ b/src/components/Meatball.jsx
@@ -3,15 +3,15 @@ import { useRef } from 'react';
 import Close from '@assets/icons/Close.svg?react';
 import Edit from '@assets/icons/Edit.svg?react';
 import More from '@assets/icons/More.svg?react';
+import { useGetQuestions } from '@context/PostContext';
 import { useClickOutside } from '@hooks/useClickOutside';
-import axios from 'axios';
+import { deleteQuestion } from '@service/api';
 import styled, { css } from 'styled-components';
 
-const baseUrl = import.meta.env.VITE_BASE_URL;
-
-function Meatball({ questionId, questionStatus, callback }) {
+function Meatball({ questionId, questionStatus, isAnswered, callback }) {
   const dropdownRef = useRef(null);
   const [isOpen, handleToggle] = useClickOutside(dropdownRef);
+  const { _, setQuestions } = useGetQuestions();
 
   const items = [
     {
@@ -26,10 +26,15 @@ function Meatball({ questionId, questionStatus, callback }) {
     {
       icon: <Close width={14} height={14} />,
       text: '삭제하기',
-      isDisable: false,
+      isDisable: !isAnswered,
       function: (questionId) => {
         // 삭제하기가 답이 달렸을 때에만 작동,
-        axios.delete(`${baseUrl}/answers/${questionId}/`);
+        deleteQuestion(questionId).then(() =>
+          setQuestions((prev) => {
+            const filteredItems = prev.filter((el) => el.id !== questionId);
+            return filteredItems;
+          }),
+        );
         handleToggle();
       },
     },

--- a/src/pages/FeedPage/components/AnswerItem.jsx
+++ b/src/pages/FeedPage/components/AnswerItem.jsx
@@ -22,6 +22,7 @@ function AnswerItem({ question, isEditable }) {
           <Meatball
             questionId={question.id}
             questionStatus={question.answer ? false : true}
+            isAnswered={question.answer ? true : false}
             callback={setIsEditMode}
           />
         )}

--- a/src/service/api.js
+++ b/src/service/api.js
@@ -65,6 +65,15 @@ export const createQuestion = async (userId, questionText) => {
   }
 };
 
+export const deleteQuestion = async (questionId) => {
+  try {
+    const response = await axios.delete(`${BASE_URL}/questions/${questionId}/`);
+    return response.data;
+  } catch (err) {
+    console.error(err.message);
+  }
+};
+
 export const createAnswer = async (questionId, answerText) => {
   try {
     const response = await axios.post(


### PR DESCRIPTION
## :construction_worker: 무엇을 했나요?
- `src/service/api.js`에 `deleteQuestion`추가
- `Meatball.jsx`에 `isAnswered`라는 답변이 달렸는지 확인하는 props 추가
- `Meatball.jsx`에 API 요청과 질문 배열에서 해당하는 questionId 빼는 로직 추가