### PR TITLE
Feature/UI/post

### DIFF
--- a/src/components/DeleteButton.jsx
+++ b/src/components/DeleteButton.jsx
@@ -1,5 +1,5 @@
 import { ButtonBrown40 } from '@components/Button.jsx';
-import { DeletePage } from '@service/api.js';
+import { deletePage } from '@service/api.js';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -7,7 +7,7 @@ function DeleteButton({ id }) {
   const navigate = useNavigate();
 
   async function handleDelete() {
-    await DeletePage(id);
+    await deletePage(id);
     navigate('/', { replace: true }); // / 으로 이동
   }
   return (

--- a/src/components/Meatball.jsx
+++ b/src/components/Meatball.jsx
@@ -11,7 +11,7 @@ const baseUrl = import.meta.env.VITE_BASE_URL;
 
 function Meatball({ questionId, questionStatus, callback }) {
   const dropdownRef = useRef(null);
-  const [isOpen, handleToggle] = useClickOutside(dropdownRef);
+  const { isOpen, handleToggle } = useClickOutside(dropdownRef);
 
   const items = [
     {

--- a/src/components/Meatball.jsx
+++ b/src/components/Meatball.jsx
@@ -5,62 +5,87 @@ import Edit from '@assets/icons/Edit.svg?react';
 import More from '@assets/icons/More.svg?react';
 import { useGetQuestions } from '@context/PostContext';
 import { useClickOutside } from '@hooks/useClickOutside';
-import { deleteQuestion } from '@service/api';
+import { createAnswer, deleteQuestion, updateAnswer } from '@service/api';
 import styled, { css } from 'styled-components';
 
-function Meatball({ questionId, questionStatus, isAnswered, callback }) {
+function Meatball({ question, isAnswered, setIsEditMode }) {
   const dropdownRef = useRef(null);
-  const { isOpen, handleToggle } = useClickOutside(dropdownRef);
-  const { _, setQuestions } = useGetQuestions();
+  const { isOpen, onToggle } = useClickOutside(dropdownRef);
+  const { setQuestions } = useGetQuestions();
 
   const items = [
     {
       icon: <Edit width={14} height={14} />,
       text: '수정하기',
-      isDisable: questionStatus,
+      isDisable: !isAnswered,
       function: () => {
-        callback(true);
-        handleToggle();
+        setIsEditMode(true);
+        onToggle();
       },
     },
     {
       icon: <Close width={14} height={14} />,
       text: '삭제하기',
       isDisable: !isAnswered,
-      function: (questionId) => {
+      function: (question) => {
         // 삭제하기가 답이 달렸을 때에만 작동,
-        deleteQuestion(questionId).then(() =>
+        deleteQuestion(question.id).then(() =>
           setQuestions((prev) => {
-            const filteredItems = prev.filter((el) => el.id !== questionId);
+            const filteredItems = prev.filter((el) => el.id !== question.id);
             return filteredItems;
           }),
         );
-        handleToggle();
+        onToggle();
+      },
+    },
+    {
+      icon: <Close width={14} height={14} />,
+      text: '답변 거절',
+      isDisable: false,
+      className: 'rejected',
+      function: async (question) => {
+        const data = isAnswered
+          ? await updateAnswer(
+              question.answer.id,
+              question.answer.content,
+              true,
+            )
+          : await createAnswer(question.id, '&nbsp;', true);
+
+        setQuestions((prev) => {
+          return prev.map((el) => {
+            return el.id === question.id ? { ...el, answer: data } : el;
+          });
+        });
+
+        setIsEditMode(false);
+        onToggle();
       },
     },
   ];
 
   return (
     <MoreButtonWrapper ref={dropdownRef}>
-      <MoreButton onClick={handleToggle}>
+      <MoreButton onClick={onToggle}>
         <More />
       </MoreButton>
-      {isOpen && <Dropdown questionId={questionId} items={items} />}
+      {isOpen && <Dropdown question={question} items={items} />}
     </MoreButtonWrapper>
   );
 }
 
 export default Meatball;
 
-function Dropdown({ questionId, items }) {
+function Dropdown({ question, items }) {
   return (
     <DropdownWrapper>
       <DropdownList>
         {items.map((el, i) => (
           <DropdownItem
             key={i}
-            onClick={() => (el.isDisable ? null : el.function(questionId))}
+            onClick={() => el.function(question)}
             isDisable={el.isDisable}
+            className={el.className ? el.className : null}
           >
             {el.icon} {el.text}
           </DropdownItem>
@@ -127,4 +152,8 @@ const DropdownItem = styled.li.withConfig({
         background-color: transparent;
       }
     `}
+
+  &.rejected {
+    color: red;
+  }
 `;

--- a/src/components/Meatball.jsx
+++ b/src/components/Meatball.jsx
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 import Close from '@assets/icons/Close.svg?react';
 import Edit from '@assets/icons/Edit.svg?react';
 import More from '@assets/icons/More.svg?react';
-import { useGetQuestions } from '@context/PostContext';
+import { useGetPost, useGetQuestions } from '@context/PostContext';
 import { useClickOutside } from '@hooks/useClickOutside';
 import { createAnswer, deleteQuestion, updateAnswer } from '@service/api';
 import styled, { css } from 'styled-components';
@@ -12,6 +12,7 @@ function Meatball({ question, isAnswered, setIsEditMode }) {
   const dropdownRef = useRef(null);
   const { isOpen, onToggle } = useClickOutside(dropdownRef);
   const { setQuestions } = useGetQuestions();
+  const { setPost } = useGetPost();
 
   const items = [
     {
@@ -26,15 +27,18 @@ function Meatball({ question, isAnswered, setIsEditMode }) {
     {
       icon: <Close width={14} height={14} />,
       text: '삭제하기',
-      isDisable: !isAnswered,
+      isDisable: false,
       function: (question) => {
         // 삭제하기가 답이 달렸을 때에만 작동,
-        deleteQuestion(question.id).then(() =>
+        deleteQuestion(question.id).then(() => {
           setQuestions((prev) => {
             const filteredItems = prev.filter((el) => el.id !== question.id);
             return filteredItems;
-          }),
-        );
+          });
+          setPost((prev) => {
+            return { ...prev, count: prev.count - 1 };
+          });
+        });
         onToggle();
       },
     },

--- a/src/pages/FeedPage/PostEditPage.jsx
+++ b/src/pages/FeedPage/PostEditPage.jsx
@@ -3,9 +3,9 @@ import { useParams } from 'react-router-dom';
 import AnswerCluster from './components/AnswerCluster';
 
 function PostEditPage() {
-  const currentId = localStorage.getItem('subjectId') ?? ''; // getItem에 들어가는 subjectId도 userId로 명칭을 정정해주는 것이 좋아 보임.
+  const currentId = JSON.parse(localStorage.getItem('userData')).id ?? '';
   const { id: userId } = useParams();
-  const isEditable = currentId === userId;
+  const isEditable = String(currentId) === userId;
 
   return (
     <>

--- a/src/pages/FeedPage/components/AnswerCluster.jsx
+++ b/src/pages/FeedPage/components/AnswerCluster.jsx
@@ -7,13 +7,10 @@ import QuestionEmpty from './QuestionEmpty';
 import QuestionList from './QuestionList';
 
 function AnswerCluster({ isEditable }) {
-  // isEditable이 자기가 만든 질문인지 아닌지 확인하는 상태값 => context로 분리를 해야하나?..
-  // 프롭스 드릴링 이슈는 어쩔수 없는듯....
   const { post } = useGetPost();
   const { id } = useParams();
 
   if (!post) {
-    // 데이터가 로딩중일때에는 로딩중...을 보여주는데, 이건 나중에 밖으로 뺄지를 고민해봐야할 것 같음.
     console.log('loading...');
     return <div>로딩중....</div>;
   }
@@ -24,7 +21,7 @@ function AnswerCluster({ isEditable }) {
       <AnswerClusterBody>
         {isEditable && (
           <DeleteButtonArea>
-            <DeleteButton subjectInfo={id} />
+            <DeleteButton id={id} />
           </DeleteButtonArea>
         )}
         <AnswerClusterWrapper>

--- a/src/pages/FeedPage/components/AnswerItem.jsx
+++ b/src/pages/FeedPage/components/AnswerItem.jsx
@@ -20,10 +20,9 @@ function AnswerItem({ question, isEditable }) {
         </Badge>
         {isEditable && (
           <Meatball
-            questionId={question.id}
-            questionStatus={question.answer ? false : true}
+            question={question}
             isAnswered={question.answer ? true : false}
-            callback={setIsEditMode}
+            setIsEditMode={setIsEditMode}
           />
         )}
       </AnswerItemUpperWrapper>

--- a/src/pages/FeedPage/components/EditableAnswer.jsx
+++ b/src/pages/FeedPage/components/EditableAnswer.jsx
@@ -6,6 +6,7 @@ import AnswerForm from './AnswerForm';
 
 const EditableAnswer = ({ answer, isEditMode, setIsEditMode }) => {
   const { setQuestions } = useGetQuestions();
+  const content = answer.isRejected ? '' : answer.content;
 
   // 답변 수정
   const handleUpdateAnswer = async (answerText) => {
@@ -29,7 +30,7 @@ const EditableAnswer = ({ answer, isEditMode, setIsEditMode }) => {
       {isEditMode ? (
         // 수정폼
         <AnswerForm
-          content={answer.content}
+          content={content}
           isEditMode={isEditMode}
           onClick={handleUpdateAnswer}
         />

--- a/src/service/api.js
+++ b/src/service/api.js
@@ -74,13 +74,17 @@ export const deleteQuestion = async (questionId) => {
   }
 };
 
-export const createAnswer = async (questionId, answerText) => {
+export const createAnswer = async (
+  questionId,
+  answerText,
+  isRejected = false,
+) => {
   try {
     const response = await axios.post(
       `${BASE_URL}/questions/${questionId}/answers/`,
       {
         content: answerText,
-        isRejected: false,
+        isRejected: isRejected,
       },
     );
     return response.data;
@@ -89,11 +93,15 @@ export const createAnswer = async (questionId, answerText) => {
   }
 };
 
-export const updateAnswer = async (answerId, answerText) => {
+export const updateAnswer = async (
+  answerId,
+  answerText,
+  isRejected = false,
+) => {
   try {
     const response = await axios.put(`${BASE_URL}/answers/${answerId}/`, {
       content: answerText,
-      isRejected: false,
+      isRejected: isRejected,
     });
     return response.data;
   } catch (err) {


### PR DESCRIPTION
## ✅작업 내역
- 답변 거절하기 기능 구현
  - isRejected의 값을 변경할 때, content에 어떠한 값이 반드시 있어야 하기 때문에 공백을 `&nbsp;` 엔티티 코드로 넣었습니다.
  - 답변 있을 때 : 사용되는 api 함수 `updateAnswer` 답변 업데이트
  - 답변 없을 때 : 사용되는 api 함수 `createAnswer` 답변 생성
  - 답변 거절에서 수정하기 클릭 시 : isRejected가 true라면, content의 값을 ''로 초기화 해주도록 적용
- localStorage 키네임을 userData로 통일
- 삭제하기 버튼 클릭시 post.count - 1 되도록 수정